### PR TITLE
Add an error dictionary for user-facing errors

### DIFF
--- a/src/LoginModule/components/Login.js
+++ b/src/LoginModule/components/Login.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Box, Typography } from '@material-ui/core';
 import { LoginForm } from './LoginForm';
 
+import errors from '../../errors';
+
 export function Login({ state, onSubmit }) {
   if (state.user) {
     return (
@@ -22,7 +24,7 @@ export function Login({ state, onSubmit }) {
       {isError && (
         <Box m={1}>
           <Typography variant="body1">
-            <b>Error: </b> {state.error}
+            <b>Error: </b> {errors[state.error] || errors.default}
           </Typography>
         </Box>
       )}

--- a/src/LoginModule/components/Login.unit.test.js
+++ b/src/LoginModule/components/Login.unit.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Login } from './Login';
+import errors from '../../errors';
 
 describe('Login', () => {
   it('renders default state', () => {
@@ -27,12 +28,12 @@ describe('Login', () => {
 
   it('renders error state', () => {
     const { getByText } = render(
-      <Login state={{ status: 'rejected', error: 'invalid password' }} />
+      <Login state={{ status: 'rejected', error: 'Missing password' }} />
     );
 
     const errorText = getByText('Error:');
     expect(errorText).toBeInTheDocument();
-    const errorMessageText = getByText('invalid password');
+    const errorMessageText = getByText(errors['Missing password']);
     expect(errorMessageText).toBeInTheDocument();
   });
 });

--- a/src/LoginModule/index.integration.test.js
+++ b/src/LoginModule/index.integration.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import { LoginModule } from './';
+import errors from '../errors';
 
 describe('LoginModule', () => {
   test('initial state', () => {
@@ -55,7 +56,7 @@ describe('LoginModule', () => {
   test('error login', async () => {
     jest
       .spyOn(window, 'fetch')
-      .mockResolvedValue({ json: () => ({ error: 'invalid password' }) });
+      .mockResolvedValue({ json: () => ({ error: 'Missing password' }) });
 
     const { getByLabelText, getByText, getByRole } = render(<LoginModule />);
 
@@ -80,7 +81,7 @@ describe('LoginModule', () => {
       // it displays error text
       const errorText = getByText('Error:');
       expect(errorText).toBeInTheDocument();
-      const errorMessageText = getByText('invalid password');
+      const errorMessageText = getByText(errors['Missing password']);
       expect(errorMessageText).toBeInTheDocument();
     });
   });

--- a/src/errors.json
+++ b/src/errors.json
@@ -1,0 +1,5 @@
+{
+  "default": "An unknown error has occurred. We're sorry!",
+  "Missing password": "Please enter a password.",
+  "user not found": "A user for these credentials has not been found - please contact the administrator."
+}


### PR DESCRIPTION
This PR adds better error messages for users, plus a default error message if we don't recognize the key.

<img width="269" alt="Screen Shot 2020-05-03 at 5 37 57 PM" src="https://user-images.githubusercontent.com/11855531/80926374-e8c9b280-8d64-11ea-8fd7-80c4d6558d1c.png">

<img width="393" alt="Screen Shot 2020-05-03 at 5 38 05 PM" src="https://user-images.githubusercontent.com/11855531/80926371-e2d3d180-8d64-11ea-9682-8624b059ee8b.png">
